### PR TITLE
Use more accurate lifetimes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midasio"
-version = "0.3.0" # Remember to also change this in the README.md
+version = "0.3.1" # Remember to also change this in the README.md
 edition = "2021"
 license = "MIT"
 description = "Utilities to read binary files in the MIDAS format"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ data banks.
 Add the following to your `Cargo.toml` file:
 ```toml
 [dependencies]
-midasio = "0.3"
+midasio = "0.3.1"
 ```
 Reading a MIDAS file is as simple as:
 ```rust

--- a/src/read/event.rs
+++ b/src/read/event.rs
@@ -830,7 +830,7 @@ impl<'a> EventView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn all_banks_slice(&self) -> &[u8] {
+    pub fn all_banks_slice(&self) -> &'a [u8] {
         let offset = EVENT_ID_LENGTH
             + EVENT_TRIGGER_MASK_LENGTH
             + EVENT_SERIAL_NUMBER_LENGTH
@@ -842,7 +842,7 @@ impl<'a> EventView<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a EventView<'a> {
+impl<'a> IntoIterator for &'_ EventView<'a> {
     type Item = BankView<'a>;
     type IntoIter = BankViews<'a>;
 

--- a/src/read/file.rs
+++ b/src/read/file.rs
@@ -493,7 +493,7 @@ impl<'a> TryFrom<&'a [u8]> for FileView<'a> {
         })
     }
 }
-impl<'a> IntoIterator for &'a FileView<'a> {
+impl<'a> IntoIterator for &'_ FileView<'a> {
     type Item = EventView<'a>;
     type IntoIter = EventViews<'a>;
 


### PR DESCRIPTION
We do not need to depend on `self` since the slice is external.

This enables use-case such as https://stackoverflow.com/q/72674000/7884305.