### PR TITLE
Fix lifetimes to refer to correct external slices

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "midasio"
-version = "0.3.1" # Remember to also change this in the README.md
+version = "0.4.0" # Remember to also change this in the README.md
 edition = "2021"
 license = "MIT"
 description = "Utilities to read binary files in the MIDAS format"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ data banks.
 Add the following to your `Cargo.toml` file:
 ```toml
 [dependencies]
-midasio = "0.3.1"
+midasio = "0.4"
 ```
 Reading a MIDAS file is as simple as:
 ```rust
@@ -23,9 +23,9 @@ use midasio::read::file::FileView;
 let contents = fs::read("example.mid")?;
 let file_view = FileView::try_from(&contents[..])?;
 
-for event in &file_view {
+for event in file_view {
     // Do something with each event in the file.
-    for bank in &event {
+    for bank in event {
         // Do something with each data bank in the event.
     }
 }

--- a/src/read.rs
+++ b/src/read.rs
@@ -13,10 +13,10 @@
 //! let contents = fs::read("example.mid")?;
 //! let file_view = FileView::try_from(&contents[..])?;
 //!
-//! for event in &file_view {
+//! for event in file_view {
 //!     // Do something with each event in the file
 //!     // ...
-//!     for bank in &event {
+//!     for bank in event {
 //!         // Do something with each data bank
 //!         // ...
 //!     }

--- a/src/read/data_bank.rs
+++ b/src/read/data_bank.rs
@@ -146,7 +146,7 @@ impl<'a> Bank16View<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         std::str::from_utf8(self.name_slice()).unwrap()
     }
 
@@ -192,7 +192,7 @@ impl<'a> Bank16View<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn data_slice(&self) -> &[u8] {
+    pub fn data_slice(&self) -> &'a [u8] {
         BankSlice::data_slice(self)
     }
 
@@ -226,7 +226,7 @@ impl<'a> Bank16View<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a Bank16View<'a> {
+impl<'a> IntoIterator for Bank16View<'a> {
     /// The type of elements being iterated over. The length of each slice is fixed to [`DataType::size()`].
     type Item = &'a [u8];
     type IntoIter = ChunksExact<'a, u8>;
@@ -247,7 +247,7 @@ impl<'a> IntoIterator for &'a Bank16View<'a> {
     ///
     /// assert_eq!(2, iter.count());
     ///
-    /// for u16_slice in &data_bank {
+    /// for u16_slice in data_bank {
     ///     assert_eq!([100, 155], u16_slice);
     /// }
     /// # Ok(())
@@ -371,7 +371,7 @@ impl<'a> Bank32View<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         std::str::from_utf8(self.name_slice()).unwrap()
     }
 
@@ -417,7 +417,7 @@ impl<'a> Bank32View<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn data_slice(&self) -> &[u8] {
+    pub fn data_slice(&self) -> &'a [u8] {
         BankSlice::data_slice(self)
     }
 
@@ -451,7 +451,7 @@ impl<'a> Bank32View<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a Bank32View<'a> {
+impl<'a> IntoIterator for Bank32View<'a> {
     /// The type of elements being iterated over. The length of each slice is fixed to [`DataType::size()`].
     type Item = &'a [u8];
     type IntoIter = ChunksExact<'a, u8>;
@@ -471,7 +471,7 @@ impl<'a> IntoIterator for &'a Bank32View<'a> {
     /// let iter = data_bank.into_iter();
     /// assert_eq!(2, iter.count());
     ///
-    /// for u16_slice in &data_bank {
+    /// for u16_slice in data_bank {
     ///     assert_eq!([100, 155], u16_slice);
     /// }
     /// # Ok(())
@@ -596,7 +596,7 @@ impl<'a> Bank32AView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         std::str::from_utf8(self.name_slice()).unwrap()
     }
 
@@ -642,7 +642,7 @@ impl<'a> Bank32AView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn data_slice(&self) -> &[u8] {
+    pub fn data_slice(&self) -> &'a [u8] {
         BankSlice::data_slice(self)
     }
 
@@ -676,7 +676,7 @@ impl<'a> Bank32AView<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a Bank32AView<'a> {
+impl<'a> IntoIterator for Bank32AView<'a> {
     /// The type of elements being iterated over. The length of each slice is fixed to [`DataType::size()`].
     type Item = &'a [u8];
     type IntoIter = ChunksExact<'a, u8>;
@@ -696,7 +696,7 @@ impl<'a> IntoIterator for &'a Bank32AView<'a> {
     /// let iter = data_bank.into_iter();
     /// assert_eq!(2, iter.count());
     ///
-    /// for u16_slice in &data_bank {
+    /// for u16_slice in data_bank {
     ///     assert_eq!([100, 155], u16_slice);
     /// }
     /// # Ok(())
@@ -769,7 +769,7 @@ impl<'a> BankView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn name(&self) -> &str {
+    pub fn name(&self) -> &'a str {
         match self {
             BankView::B16(bank) => bank.name(),
             BankView::B32(bank) => bank.name(),
@@ -819,7 +819,7 @@ impl<'a> BankView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn data_slice(&self) -> &[u8] {
+    pub fn data_slice(&self) -> &'a [u8] {
         match self {
             BankView::B16(bank) => bank.data_slice(),
             BankView::B32(bank) => bank.data_slice(),
@@ -941,7 +941,7 @@ impl<'a> BankView<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'a BankView<'a> {
+impl<'a> IntoIterator for BankView<'a> {
     /// The type of elements being iterated over. The length of each slice is fixed to [`DataType::size()`].
     type Item = &'a [u8];
     type IntoIter = ChunksExact<'a, u8>;
@@ -961,7 +961,7 @@ impl<'a> IntoIterator for &'a BankView<'a> {
     /// let iter = bank_32.into_iter();
     /// assert_eq!(4, iter.count());
     ///
-    /// for u8_slice in &bank_32 {
+    /// for u8_slice in bank_32 {
     ///     assert_eq!([100], u8_slice);
     /// }
     /// # Ok(())
@@ -985,7 +985,7 @@ impl<'a> IntoIterator for &'a BankView<'a> {
 //    types (see [`Type`] enum and the valid TryFrom conversions).
 // 4) The "size" field correctly matches the size of the data in the bank.
 // 5) The data slice should contain an integer number of [`DataType`] items.
-pub(in crate::read) trait BankSlice {
+pub(in crate::read) trait BankSlice<'a> {
     // Number of ASCII alphanumeric characters that determine the name of the data bank.
     const NAME_LENGTH: usize;
     // Number of bytes that represent the [`DataType`] field in the data bank.
@@ -1000,48 +1000,48 @@ pub(in crate::read) trait BankSlice {
         Self::NAME_LENGTH + Self::TYPE_LENGTH + Self::SIZE_LENGTH + Self::FOOTER_LENGTH;
 
     // Return a complete slice of bytes that represent a data bank (header plus data).
-    fn data_bank_slice(&self) -> &[u8];
+    fn data_bank_slice(&self) -> &'a [u8];
     // Return the endianness of the bank
     fn endianness(&self) -> Endianness;
 
     // Return the slice of bytes in the data bank which represent its name.
-    fn name_slice(&self) -> &[u8] {
+    fn name_slice(&self) -> &'a [u8] {
         &self.data_bank_slice()[..Self::NAME_LENGTH]
     }
 
     // Return the slice of bytes in the data bank which represent the data type.
-    fn data_type_slice(&self) -> &[u8] {
+    fn data_type_slice(&self) -> &'a [u8] {
         let offset = Self::NAME_LENGTH;
         &self.data_bank_slice()[offset..][..Self::TYPE_LENGTH]
     }
 
     // Return the slice of bytes in the bank which represent the data size.
-    fn data_size_slice(&self) -> &[u8] {
+    fn data_size_slice(&self) -> &'a [u8] {
         let offset = Self::NAME_LENGTH + Self::TYPE_LENGTH;
         &self.data_bank_slice()[offset..][..Self::SIZE_LENGTH]
     }
 
     // Return the reserved bytes between the header and the data.
-    fn header_footer_slice(&self) -> &[u8] {
+    fn header_footer_slice(&self) -> &'a [u8] {
         let offset = Self::NAME_LENGTH + Self::TYPE_LENGTH + Self::SIZE_LENGTH;
         &self.data_bank_slice()[offset..][..Self::FOOTER_LENGTH]
     }
 
     // Return the actual data slice.
-    fn data_slice(&self) -> &[u8] {
+    fn data_slice(&self) -> &'a [u8] {
         let offset =
             Self::NAME_LENGTH + Self::TYPE_LENGTH + Self::SIZE_LENGTH + Self::FOOTER_LENGTH;
         &self.data_bank_slice()[offset..]
     }
 }
 
-impl BankSlice for Bank16View<'_> {
+impl<'a> BankSlice<'a> for Bank16View<'a> {
     const NAME_LENGTH: usize = crate::B16_NAME_LENGTH;
     const TYPE_LENGTH: usize = crate::B16_DATA_TYPE_LENGTH;
     const SIZE_LENGTH: usize = crate::B16_SIZE_LENGTH;
     const FOOTER_LENGTH: usize = crate::B16_RESERVED_LENGTH;
 
-    fn data_bank_slice(&self) -> &[u8] {
+    fn data_bank_slice(&self) -> &'a [u8] {
         self.slice
     }
     fn endianness(&self) -> Endianness {
@@ -1049,13 +1049,13 @@ impl BankSlice for Bank16View<'_> {
     }
 }
 
-impl BankSlice for Bank32View<'_> {
+impl<'a> BankSlice<'a> for Bank32View<'a> {
     const NAME_LENGTH: usize = crate::B32_NAME_LENGTH;
     const TYPE_LENGTH: usize = crate::B32_DATA_TYPE_LENGTH;
     const SIZE_LENGTH: usize = crate::B32_SIZE_LENGTH;
     const FOOTER_LENGTH: usize = crate::B32_RESERVED_LENGTH;
 
-    fn data_bank_slice(&self) -> &[u8] {
+    fn data_bank_slice(&self) -> &'a [u8] {
         self.slice
     }
     fn endianness(&self) -> Endianness {
@@ -1063,13 +1063,13 @@ impl BankSlice for Bank32View<'_> {
     }
 }
 
-impl BankSlice for Bank32AView<'_> {
+impl<'a> BankSlice<'a> for Bank32AView<'a> {
     const NAME_LENGTH: usize = crate::B32A_NAME_LENGTH;
     const TYPE_LENGTH: usize = crate::B32A_DATA_TYPE_LENGTH;
     const SIZE_LENGTH: usize = crate::B32A_SIZE_LENGTH;
     const FOOTER_LENGTH: usize = crate::B32A_RESERVED_LENGTH;
 
-    fn data_bank_slice(&self) -> &[u8] {
+    fn data_bank_slice(&self) -> &'a [u8] {
         self.slice
     }
     fn endianness(&self) -> Endianness {
@@ -1086,7 +1086,7 @@ fn are_all_ascii_alphanumeric(slice: &[u8]) -> bool {
     true
 }
 
-fn error_in_bank_view<T: BankSlice>(bank: &T) -> Result<(), TryBankViewFromSliceError> {
+fn error_in_bank_view<'a, T: BankSlice<'a>>(bank: &T) -> Result<(), TryBankViewFromSliceError> {
     if bank.data_bank_slice().len() < T::HEADER_LENGTH {
         return Err(TryBankViewFromSliceError::SizeMismatch);
     }

--- a/src/read/data_bank/tests.rs
+++ b/src/read/data_bank/tests.rs
@@ -182,7 +182,7 @@ fn iterator_bank16_views() {
     let buffer = [66u8, 65, 78, 75, 1, 0, 5, 0, 1, 1, 1, 1, 1];
     let bank = Bank16View::try_from_le_bytes(&buffer).unwrap();
     assert_eq!(5, bank.into_iter().count());
-    for num in &bank {
+    for num in bank {
         let num = u8::from_le_bytes(num.try_into().unwrap());
         assert_eq!(1, num);
     }
@@ -379,7 +379,7 @@ fn iterator_bank32_views() {
     let buffer = [66u8, 65, 78, 75, 1, 0, 0, 0, 5, 0, 0, 0, 1, 1, 1, 1, 1];
     let bank = Bank32View::try_from_le_bytes(&buffer).unwrap();
     assert_eq!(5, bank.into_iter().count());
-    for num in &bank {
+    for num in bank {
         let num = u8::from_le_bytes(num.try_into().unwrap());
         assert_eq!(1, num);
     }
@@ -598,7 +598,7 @@ fn iterator_bank32a_views() {
     ];
     let bank = Bank32AView::try_from_le_bytes(&buffer).unwrap();
     assert_eq!(5, bank.into_iter().count());
-    for num in &bank {
+    for num in bank {
         let num = u8::from_le_bytes(num.try_into().unwrap());
         assert_eq!(1, num);
     }

--- a/src/read/event.rs
+++ b/src/read/event.rs
@@ -92,7 +92,7 @@ impl<'a> Bank16Views<'a> {
     /// banks.next();
     /// assert_eq!([1, 1], banks.remainder());
     /// ```
-    pub fn remainder(&self) -> &[u8] {
+    pub fn remainder(&self) -> &'a [u8] {
         &self.slice[self.curr..]
     }
 }
@@ -221,7 +221,7 @@ impl<'a> Bank32Views<'a> {
     /// banks.next();
     /// assert_eq!([1, 1], banks.remainder());
     /// ```
-    pub fn remainder(&self) -> &[u8] {
+    pub fn remainder(&self) -> &'a [u8] {
         &self.slice[self.curr..]
     }
 }
@@ -350,7 +350,7 @@ impl<'a> Bank32AViews<'a> {
     /// banks.next();
     /// assert_eq!([1, 1], banks.remainder());
     /// ```
-    pub fn remainder(&self) -> &[u8] {
+    pub fn remainder(&self) -> &'a [u8] {
         &self.slice[self.curr..]
     }
 }
@@ -437,7 +437,7 @@ impl<'a> BankViews<'a> {
     /// banks.next();
     /// assert_eq!([1, 1], banks.remainder());
     /// ```
-    pub fn remainder(&self) -> &[u8] {
+    pub fn remainder(&self) -> &'a [u8] {
         match self {
             BankViews::B16(iter) => &iter.slice[iter.curr..],
             BankViews::B32(iter) => &iter.slice[iter.curr..],
@@ -526,7 +526,7 @@ impl Error for TryEventViewFromSliceError {}
 ///     .collect();
 /// let event = EventView::try_from_be_bytes(&event)?;
 ///
-/// for bank in &event {
+/// for bank in event {
 ///     assert_eq!("BANK", bank.name());
 ///     assert_eq!([255], bank.data_slice());
 /// }
@@ -842,7 +842,7 @@ impl<'a> EventView<'a> {
     }
 }
 
-impl<'a> IntoIterator for &'_ EventView<'a> {
+impl<'a> IntoIterator for EventView<'a> {
     type Item = BankView<'a>;
     type IntoIter = BankViews<'a>;
 

--- a/src/read/event/tests.rs
+++ b/src/read/event/tests.rs
@@ -563,7 +563,7 @@ fn valid_b16_le_event_view() {
     assert_eq!(4, event.timestamp());
     assert_eq!(1, event.flags());
 
-    for bank in &event {
+    for bank in event {
         assert_eq!("BANK", bank.name());
         assert_eq!([255], bank.data_slice());
     }
@@ -594,7 +594,7 @@ fn valid_b16_be_event_view() {
     assert_eq!(4, event.timestamp());
     assert_eq!(1, event.flags());
 
-    for bank in &event {
+    for bank in event {
         assert_eq!("BANK", bank.name());
         assert_eq!([255], bank.data_slice());
     }
@@ -753,7 +753,7 @@ fn valid_b32_le_event_view() {
     assert_eq!(4, event.timestamp());
     assert_eq!(17, event.flags());
 
-    for bank in &event {
+    for bank in event {
         assert_eq!("BANK", bank.name());
         assert_eq!([255], bank.data_slice());
     }
@@ -784,7 +784,7 @@ fn valid_b32a_le_event_view() {
     assert_eq!(4, event.timestamp());
     assert_eq!(49, event.flags());
 
-    for bank in &event {
+    for bank in event {
         assert_eq!("BANK", bank.name());
         assert_eq!([255], bank.data_slice());
     }

--- a/src/read/file.rs
+++ b/src/read/file.rs
@@ -322,7 +322,7 @@ impl<'a> FileView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn initial_odb(&self) -> &[u8] {
+    pub fn initial_odb(&self) -> &'a [u8] {
         let offset = ODB_ID_LENGTH + ODB_MI_LENGTH + ODB_RUN_NUMBER_LENGTH + ODB_TIME_STAMP_LENGTH;
         let size = self.slice[offset..][..ODB_SIZE_LENGTH].try_into().unwrap();
         let size: usize = match self.endianness {
@@ -380,7 +380,7 @@ impl<'a> FileView<'a> {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn final_odb(&self) -> &[u8] {
+    pub fn final_odb(&self) -> &'a [u8] {
         let mut events = self.into_iter();
         for _ in events.by_ref() {}
 
@@ -493,7 +493,7 @@ impl<'a> TryFrom<&'a [u8]> for FileView<'a> {
         })
     }
 }
-impl<'a> IntoIterator for &'_ FileView<'a> {
+impl<'a> IntoIterator for FileView<'a> {
     type Item = EventView<'a>;
     type IntoIter = EventViews<'a>;
 


### PR DESCRIPTION
From PR #8 it was noted an issue with the lifetimes on all the `Viewer` structures. This PR fixes all these issues and correctly annotates that the lifetime of all slices returned by a `Viewer` matches that of the input slice (the binary file).

This introduces a breaking change where the implementation of `IntoIterator` of `&'a FileView`, `&'a EventView`, and `&'a BankView` are replaced for implementation for `FileView<'a>`, `EventView<'a>`, and `BankView<'a>`. This new iterator API allows for a much more flexible usage e.g. `flatten()` and chaining iterators while the external byte slice is in scope.